### PR TITLE
Fn4 bucket name

### DIFF
--- a/modules/analysis.nf
+++ b/modules/analysis.nf
@@ -164,7 +164,7 @@ process FN4_upload {
     FN4ormater.py -i ${sampleName}_wuhan.fa -r MN908947.3 -s ${sampleName} -o ${sampleName}.fasta
 
     oci os object put \
-	-bn $bucketName \
+	-bn ${params.bucketNameFN4} \
 	--force \
         --auth instance_principal \
 	--file ${sampleName}.fasta \

--- a/nextflow.config
+++ b/nextflow.config
@@ -10,7 +10,7 @@ params {
   //other
   uploadBucket=false
   prefix=params.seq_tech
-  bucketName = 'FN4-queue'
+  bucketNameFN4 = 'FN4-queue'
 }
 
 


### PR DESCRIPTION
`bucketNameFN4` is now accepted as a parameter. Required because PROD and DEV now have different buckets for FN4