### PR TITLE
Changes to enable kubernetes running

### DIFF
--- a/bin/makeReport.py
+++ b/bin/makeReport.py
@@ -20,7 +20,7 @@ df=df.merge(aln2type, on='sampleName', how='left', suffixes=(None,"_aln2type"))
 # versions
 wf=open('workflow_commit.txt').read()
 df['workflowCommit']=str(wf).strip()
-df['manifestVerison']=sys.argv[2]
+df['manifestVersion']=sys.argv[2]
 nextclade_version=open('nextclade_files/version.txt').read()
 df['nextcladeVersion']=str(nextclade_version).strip()
 aln2type_variant_commit=open('variant_definitions/aln2type_variant_git_commit.txt').read()
@@ -54,7 +54,7 @@ a={level: aln2type.xs(level).to_dict('index') for level in aln2type.index.levels
 
 w={'WorkflowInformation':{}}
 w['WorkflowInformation']['workflowCommit']=str(wf).strip()
-w['WorkflowInformation']['manifestVerison']=sys.argv[2]
+w['WorkflowInformation']['manifestVersion']=sys.argv[2]
 w['WorkflowInformation']['sampleIdentifier']=sample_name
 
 # add fasta to json

--- a/environments/Dockerfile
+++ b/environments/Dockerfile
@@ -1,4 +1,4 @@
 FROM ubuntu:20.04
 
-RUN apt update && apt install -y python3-pip
+RUN apt update && apt install -y python3-pip git
 RUN pip install biopython pandas

--- a/modules/analysis.nf
+++ b/modules/analysis.nf
@@ -166,7 +166,7 @@ process FN4_upload {
     oci os object put \
 	-bn ${params.bucketNameFN4} \
 	--force \
-        --auth instance_principal \
+    --auth instance_principal \
 	--file ${sampleName}.fasta \
 	--metadata "{\\"sampleID\\":\\"$sampleName\\"}"
 

--- a/modules/analysis.nf
+++ b/modules/analysis.nf
@@ -95,6 +95,7 @@ process getVariantDefinitions {
 }
 
 process getWorkflowCommit {
+    label 'sars_cov2_workflows'
 
     output:
     path "workflowcommit.txt", emit: commit

--- a/modules/analysis.nf
+++ b/modules/analysis.nf
@@ -1,5 +1,6 @@
 process pango {
     tag { sampleName }
+    label 'pango'
 
     publishDir "${params.outdir}/analysis/pango/${params.prefix}", mode: 'copy'
 
@@ -31,6 +32,8 @@ process  download_primers {
 
 
 process download_nextclade_files {
+    label 'nextclade'
+
     publishDir "${params.outdir}/analysis/nextclade/${params.prefix}", mode: 'copy'
     output:
     file('nextclade_files')
@@ -49,6 +52,7 @@ process download_nextclade_files {
 
 process nextclade {
     tag { sampleName }
+    label 'nextclade'
 
     publishDir "${params.outdir}/analysis/nextclade/${params.prefix}", mode: 'copy'
 
@@ -72,6 +76,8 @@ process nextclade {
 }
 
 process getVariantDefinitions {
+    label 'aln2type'
+
     publishDir "${params.outdir}/analysis/aln2type/${params.prefix}", mode: 'copy'
 
     output:
@@ -102,6 +108,7 @@ process getWorkflowCommit {
 
 process aln2type {
     tag { sampleName }
+    label 'aln2type'
 
     publishDir "${params.outdir}/analysis/aln2type/${params.prefix}", mode: 'copy'
 
@@ -129,6 +136,7 @@ process aln2type {
 
 process makeReport {
     tag { sampleName }
+    label 'sars_cov2_workflows'
 
     publishDir "${params.outdir}/analysis/report/${params.prefix}", mode: 'copy'
 
@@ -149,6 +157,7 @@ process makeReport {
 
 process FN4_upload {
     tag { sampleName }
+    label 'fn4'
 
     input:
     tuple(val(sampleName),  file('consensus.fasta'), path(variant_definitions), path(reffasta), path("*"))
@@ -175,6 +184,7 @@ process FN4_upload {
 
 
 process getGFF3 {
+    label 'bcftools'
 
     output:
     path "MN908947.3.gff3"
@@ -189,6 +199,7 @@ process getGFF3 {
 
 process bcftools_csq {
     tag { sampleName }
+    label 'bcftools'
 
     publishDir "${params.outdir}/analysis/bcftools/${params.prefix}", mode: 'copy'
 

--- a/modules/utils.nf
+++ b/modules/utils.nf
@@ -6,6 +6,7 @@ process getObjFiles {
     */
 
     tag { prefix }
+    label 'oci_pipe'
 
     input:
         tuple val(bucket), val(filePrefix), val(prefix)
@@ -37,6 +38,7 @@ process getObjFilesONT {
     */
 
     tag { prefix }
+    label 'oci_pipe'
 
     input:
         tuple val(bucket), val(filePrefix), val(prefix)

--- a/modules/utils.nf
+++ b/modules/utils.nf
@@ -113,6 +113,8 @@ process getObjCsv {
 
     //tag { prefix }
 
+    label 'oci_pipe'
+
     input:
         tuple val(bucket), val(path)
 

--- a/modules/viridian.nf
+++ b/modules/viridian.nf
@@ -6,6 +6,7 @@ process viridianPrimers {
     */
 
     tag { prefix }
+    label 'viridian'
     publishDir "${params.outdir}/consensus_seqs/", mode: 'copy', saveAs: { filename -> filename.endsWith(".fa") ? "${prefix}.fasta":null}
     publishDir "${params.outdir}/VCF/", mode: 'copy', saveAs: { filename -> filename.endsWith(".vcf") ? "${prefix}.vcf":null}
     publishDir "${params.outdir}/qc/", mode: 'copy', saveAs: { filename -> filename.endsWith(".json") ? "${prefix}.json":null}
@@ -46,8 +47,7 @@ process viridianAuto {
     */
 
     tag { prefix }
-
-    tag { prefix }
+    label 'viridian'
     publishDir "${params.outdir}/consensus_seqs/", mode: 'copy', saveAs: { filename -> filename.endsWith(".fa") ? "${prefix}.fasta":null}
     publishDir "${params.outdir}/VCF/", mode: 'copy', saveAs: { filename -> filename.endsWith(".vcf") ? "${prefix}.vcf":null}
     publishDir "${params.outdir}/qc/", mode: 'copy', saveAs: { filename -> filename.endsWith(".json") ? "${prefix}.json":null}
@@ -87,6 +87,7 @@ process viridianONTPrimers {
     */
 
     tag { prefix }
+    label 'viridian'
     publishDir "${params.outdir}/consensus_seqs/", mode: 'copy', saveAs: { filename -> filename.endsWith(".fa") ? "${prefix}.fasta":null}
     publishDir "${params.outdir}/VCF/", mode: 'copy', saveAs: { filename -> filename.endsWith(".vcf") ? "${prefix}.vcf":null}
     publishDir "${params.outdir}/qc/", mode: 'copy', saveAs: { filename -> filename.endsWith(".json") ? "${prefix}.json":null}
@@ -124,6 +125,7 @@ process viridianONTAuto {
     */
 
     tag { prefix }
+    label 'viridian'
     publishDir "${params.outdir}/consensus_seqs/", mode: 'copy', saveAs: { filename -> filename.endsWith(".fa") ? "${prefix}.fasta":null}
     publishDir "${params.outdir}/VCF/", mode: 'copy', saveAs: { filename -> filename.endsWith(".vcf") ? "${prefix}.vcf":null}
     publishDir "${params.outdir}/qc/", mode: 'copy', saveAs: { filename -> filename.endsWith(".json") ? "${prefix}.json":null}

--- a/nextflow.config
+++ b/nextflow.config
@@ -54,42 +54,42 @@ profiles {
             withLabel:oci_pipe {
                 time = '30m'
                 singularity.enabled = true
-                container = '/data/images/oci_pipeline_v0.1.24.sif'
+                container = '/data/images/oci_pipeline_v0.2.21.sif'
             }
             withLabel:pango {
                 time = '5m'
                 singularity.enabled = true
-                container = '/data/images/pango_v0.1.24.sif'
+                container = '/data/images/pango_v0.2.21.sif'
             }
             withLabel:nextclade {
                 time = '1h'
                 singularity.enabled = true
-                container = '/data/images/nextclade_v0.1.24.sif'
+                container = '/data/images/nextclade_v0.2.21.sif'
             }
             withLabel:aln2type {
                 time = '1h'
                 singularity.enabled = true
-                container = '/data/images/aln2type_v0.1.24.sif'
+                container = '/data/images/aln2type_v0.2.21.sif'
             }
             withLabel:viridian {
                 time = '45m'
                 singularity.enabled = true
-                container = '/data/images/viridian_workflow_v0.3.4.img'
+                container = '/data/images/viridian_workflow_v0.3.7.img'
             }
             withLabel:fn4 {
                 time = '1h'
                 singularity.enabled = true
-                container = '/data/images/fn4_upload_v0.1.24.sif'
+                container = '/data/images/fn4_upload_v0.2.21.sif'
             }
             withName:sars_cov2_workflows {
                 time = '1h'
                 singularity.enabled = true
-                container = "/data/images/sars-cov2_workflows_v2.0.0.sif"
+                container = "/data/images/sars-cov2_workflows_v2.0.4.sif"
             }
             withLabel:bcftools {
                 time = '1h'
                 singularity.enabled = true
-                container = "/data/images/bcftools_v0.1.24.sif"
+                container = "/data/images/bcftools_v0.2.21.sif"
             }
         }
     }

--- a/nextflow.config
+++ b/nextflow.config
@@ -163,7 +163,7 @@ profiles {
             }
             withLabel:sars_cov2_workflows {
                 time = '1h'
-                container = 'lhr.ocir.io/lrbvkel2wjot/oxfordmmm/sars-cov2_workflows:v2.0.4-test'
+                container = 'lhr.ocir.io/lrbvkel2wjot/oxfordmmm/sars-cov2_workflows:v2.0.4'
             }
             withLabel:bcftools {
                 time = '1h'

--- a/nextflow.config
+++ b/nextflow.config
@@ -11,6 +11,21 @@ params {
   uploadBucket=false
   prefix=params.seq_tech
   bucketNameFN4 = 'FN4-queue'
+
+  // parallel processing operation limit
+  myQueueSize = 100000
+
+  // number of maximum retries for errored processes
+  myMaxRetries = 5
+
+  // total number of error allowed per job 
+  myMaxErrors = 1000
+
+  // process fork limit
+  myMaxForks = false
+
+  // execution UUID
+  run_uuid = 'no_uuid'
 }
 
 
@@ -36,90 +51,45 @@ profiles {
         singularity.autoMounts = true
 
         process {
-            withName:getObjCsv {
+            withLabel:oci_pipe {
                 time = '30m'
                 singularity.enabled = true
                 container = '/data/images/oci_pipeline_v0.1.24.sif'
             }
-            withName:getObjFilesONT {
-                time = '30m'
-                singularity.enabled = true
-                container = '/data/images/oci_pipeline_v0.1.24.sif'
-            }
-            withName:pango {
+            withLabel:pango {
                 time = '5m'
                 singularity.enabled = true
                 container = '/data/images/pango_v0.1.24.sif'
             }
-            withName:nextclade {
-                time = '5m'
-                singularity.enabled = true
-                container = '/data/images/nextclade_v0.1.24.sif'
-            }
-            withName:download_nextclade_files {
+            withLabel:nextclade {
                 time = '1h'
                 singularity.enabled = true
                 container = '/data/images/nextclade_v0.1.24.sif'
             }
-            withName:getVariantDefinitions {
+            withLabel:aln2type {
                 time = '1h'
                 singularity.enabled = true
                 container = '/data/images/aln2type_v0.1.24.sif'
             }
-            withName:aln2type {
-                time = '5m'
-                singularity.enabled = true
-                container = '/data/images/aln2type_v0.1.24.sif'
-            }
-            withName:viridianONTPrimers {
+            withLabel:viridian {
                 time = '45m'
                 singularity.enabled = true
                 container = '/data/images/viridian_workflow_v0.3.4.img'
             }
-            withName:viridianONTAuto {
-                time = '45m'
-                singularity.enabled = true
-                container = '/data/images/viridian_workflow_v0.3.4.img'
-            }
-            withName:viridianPrimers {
-                time = '45m'
-                singularity.enabled = true
-                container = '/data/images/viridian_workflow_v0.3.4.img'
-            }
-            withName:viridianAuto {
-                time = '45m'
-                singularity.enabled = true
-                container = '/data/images/viridian_workflow_v0.3.4.img'
-            }
-            withName:FN4_upload {
+            withLabel:fn4 {
                 time = '1h'
                 singularity.enabled = true
                 container = '/data/images/fn4_upload_v0.1.24.sif'
             }
-            withName:uploadToBucket {
-                time = '1h'
-                singularity.enabled = true
-                container = '/data/images/fn4_upload_v0.1.24.sif'
-            }
-            withName:makeReport {
+            withName:sars_cov2_workflows {
                 time = '1h'
                 singularity.enabled = true
                 container = "/data/images/sars-cov2_workflows_v2.0.0.sif"
             }
-            withName:getGFF3 {
+            withLabel:bcftools {
                 time = '1h'
                 singularity.enabled = true
                 container = "/data/images/bcftools_v0.1.24.sif"
-            }
-            withName:bcftools_csq {
-                time = '1h'
-                singularity.enabled = true
-                container = "/data/images/bcftools_v0.1.24.sif"
-            }
-            withName:getObjFiles {
-                time = '30m'
-                singularity.enabled = true
-                container = '/data/images/oci_pipeline_v0.1.24.sif'
             }
         }
     }
@@ -130,6 +100,6 @@ manifest {
   description = 'SARS-CoV2 worfklows for GPAS'
   mainScript = 'main.nf'
   nextflowVersion = '>=20.01.0'
-  version = 'sp3env-v0.1.3'
+  version = 'sp3env-v0.2.21'
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -163,7 +163,7 @@ profiles {
             }
             withLabel:sars_cov2_workflows {
                 time = '1h'
-                container = 'lhr.ocir.io/lrbvkel2wjot/oxfordmmm/sars-cov2_workflows_v2.0.4-test'
+                container = 'lhr.ocir.io/lrbvkel2wjot/oxfordmmm/sars-cov2_workflows:v2.0.4-test'
             }
             withLabel:bcftools {
                 time = '1h'

--- a/nextflow.config
+++ b/nextflow.config
@@ -31,14 +31,9 @@ params {
 
 profiles {
     singularity {
-        process {
-            scratch = true
-	        errorStrategy = 'ignore'
-        }
         report {
 	        enabled = true
         }
-
         timeline {
             enabled = true
         }
@@ -51,6 +46,9 @@ profiles {
         singularity.autoMounts = true
 
         process {
+            scratch = true
+	        errorStrategy = 'ignore'
+
             withLabel:oci_pipe {
                 time = '30m'
                 singularity.enabled = true
@@ -93,6 +91,85 @@ profiles {
             }
         }
     }
+
+    oke {
+        k8s {
+            namespace = 'default'
+            storageClaimName = 'default-nextflow-fss-storage-work-pvc'
+            storageMountPath = '/work'
+            launchDir = "/work/runs/${params.run_uuid}"
+
+            serviceAccount = 'default'
+            projectDir = '/work/project'
+            pod = [
+                [label: 'pod-type', value: 'nextflow-worker'],
+                [volumeClaim: 'default-nextflow-fss-storage-data-pvc', mountPath: '/data'],
+                [imagePullSecret: 'sp3dockersecret'],
+                [imagePullPolicy: 'IfNotPresent']
+            ]
+        }
+        report {
+            enabled = true
+        }
+        timeline {
+            enabled = true
+        }
+        dag {
+            enabled = true
+        }
+        trace {
+            enabled = true
+        }
+
+        process {
+            executor = 'k8s'
+            scratch = true
+            // Exponential backoff: 2s, 4s, 8s, 16s, 32s, and 1min thereafter.
+            errorStrategy = {
+                sleep(Math.max(60000, Math.pow(2, task.attempt) * 2000) as long)
+                return 'retry'
+            }
+            maxRetries = params.myMaxRetries
+            maxErrors = params.myMaxErrors
+            if (params.myMaxForks) {
+                maxForks = params.myMaxForks
+            }
+
+            container = 'lhr.ocir.io/lrbvkel2wjot/oxfordmmm/nf-head-pod:0c8df09c8e58'
+
+            withLabel:oci_pipe {
+                time = '30m'
+                container = 'lhr.ocir.io/lrbvkel2wjot/oxfordmmm/oci_pipeline:v0.2.21'
+            }
+            withLabel:pango {
+                time = '5m'
+                container = 'lhr.ocir.io/lrbvkel2wjot/oxfordmmm/pango:v0.2.21'
+            }
+            withLabel:nextclade {
+                time = '1h'
+                container = 'lhr.ocir.io/lrbvkel2wjot/nextclade:1.11.0'
+            }
+            withLabel:aln2type {
+                time = '1h'
+                container = 'lhr.ocir.io/lrbvkel2wjot/oxfordmmm/aln2type:v0.2.9'
+            }
+            withLabel:viridian {
+                time = '45m'
+                container = 'lhr.ocir.io/lrbvkel2wjot/viridian_workflow:v0.3.7'
+            }
+            withLabel:fn4 {
+                time = '1h'
+                container = 'lhr.ocir.io/lrbvkel2wjot/oxfordmmm/fn4_upload:v0.2.9'
+            }
+            withName:sars_cov2_workflows {
+                time = '1h'
+                container = 'lhr.ocir.io/lrbvkel2wjot/oxfordmmm/sars-cov2_workflows_v2.0.4'
+            }
+            withLabel:bcftools {
+                time = '1h'
+                container = 'lhr.ocir.io/lrbvkel2wjot/oxfordmmm/bcftools:v0.2.9'
+            }
+        }
 }
 
 manifest {

--- a/nextflow.config
+++ b/nextflow.config
@@ -163,7 +163,7 @@ profiles {
             }
             withLabel:sars_cov2_workflows {
                 time = '1h'
-                container = 'lhr.ocir.io/lrbvkel2wjot/oxfordmmm/sars-cov2_workflows_v2.0.4'
+                container = 'lhr.ocir.io/lrbvkel2wjot/oxfordmmm/sars-cov2_workflows_v2.0.4-test'
             }
             withLabel:bcftools {
                 time = '1h'

--- a/nextflow.config
+++ b/nextflow.config
@@ -79,7 +79,7 @@ profiles {
                 singularity.enabled = true
                 container = '/data/images/fn4_upload_v0.2.21.sif'
             }
-            withName:sars_cov2_workflows {
+            withLabel:sars_cov2_workflows {
                 time = '1h'
                 singularity.enabled = true
                 container = "/data/images/sars-cov2_workflows_v2.0.4.sif"
@@ -161,7 +161,7 @@ profiles {
                 time = '1h'
                 container = 'lhr.ocir.io/lrbvkel2wjot/oxfordmmm/fn4_upload:v0.2.9'
             }
-            withName:sars_cov2_workflows {
+            withLabel:sars_cov2_workflows {
                 time = '1h'
                 container = 'lhr.ocir.io/lrbvkel2wjot/oxfordmmm/sars-cov2_workflows_v2.0.4'
             }

--- a/nextflow.config
+++ b/nextflow.config
@@ -170,6 +170,7 @@ profiles {
                 container = 'lhr.ocir.io/lrbvkel2wjot/oxfordmmm/bcftools:v0.2.9'
             }
         }
+    }
 }
 
 manifest {

--- a/tests/GPAS_tests_short.bash
+++ b/tests/GPAS_tests_short.bash
@@ -27,7 +27,7 @@ popd
 # ont_viridian_test
 test_name=gpas_ont_short
 echo Running ${test_name} test workflow
-kdir -p /work/runs/${test_name}_test
+mkdir -p /work/runs/${test_name}_test
 cd /work/runs/${test_name}_test
 
 nextflow pull oxfordmmm/${repo} -r ${git_version}

--- a/tests/GPAS_tests_short.bash
+++ b/tests/GPAS_tests_short.bash
@@ -1,49 +1,58 @@
 #!/bin/bash
 
+sudo mkdir -p /work/tmp
+sudo chown ubuntu:ubuntu /work/tmp
 
 echo \
 "SARS-CoV-2_reference_ox,mmm-artic-ill-s11511-1
 SARS-CoV-2_reference_ox,mmm-artic-ill-s12220-1
 SARS-CoV-2_reference_ox,mmm-artic-ill-s12368-1
 SARS-CoV-2_reference_ox,mmm-artic-ill-s16621-1" \
-    > /tmp/illumina_data_short.csv
+    > /work/tmp/illumina_data_short.csv
 
 echo \
 "SARS-CoV-2_reference_ox,mmm-artic-ont-s11511-1
 SARS-CoV-2_reference_ox,mmm-artic-ont-s12220-4
 SARS-CoV-2_reference_ox,mmm-artic-ont-s12368-1
 SARS-CoV-2_reference_ox,mmm-artic-ont-s16621-3" \
-    > /tmp/ONT_data_short.csv
+    > /work/tmp/ONT_data_short.csv
 
-repo='/data/pipelines/SARS-CoV2_workflows'
+repo='SARS-CoV2_workflows'
 comp_venv='/home/ubuntu/env'
+
+pushd /data/pipelines/${repo}
+git_version=$(git describe --tags)
+popd
+
 # ont_viridian_test
 test_name=gpas_ont_short
 echo Running ${test_name} test workflow
-mkdir -p /work/runs/${test_name}_test
+kdir -p /work/runs/${test_name}_test
 cd /work/runs/${test_name}_test
 
-nextflow run \
-        ${repo}/main.nf \
+nextflow pull oxfordmmm/${repo} -r ${git_version}
+
+nextflow kuberun \
+        oxfordmmm/${repo} \
         -with-trace -with-report -with-timeline -with-dag dag.png \
+        -r ${git_version} -latest \
         --seq_tech nanopore \
-        -profile singularity \
-        -process.executor slurm \
-        --objstore /tmp/ONT_data_short.csv \
+        -profile oke \
+        --objstore /work/tmp/ONT_data_short.csv \
         --TESToutputMODE true \
         --outdir /work/output/${test_name}_test \
-        > nextflow.txt
+        > ${test_name}_nextflow.txt
 
 if ! [ -z ${comp_venv} ]
 then
     source $comp_venv/bin/activate
 fi
 
-python3 ${repo}/tests/GPAS_tests_summary.py \
+python3 /data/pipelines/${repo}/tests/GPAS_tests_summary.py \
     -w /work/runs/${test_name}_test \
     -i /work/output/${test_name}_test/ \
     -t /work/output/${test_name}_test/${test_name}_summary.tsv  \
-    -e ${repo}/tests/${test_name}_expected.tsv \
+    -e /data/pipelines/${repo}/tests/${test_name}_expected.tsv \
     -c /work/output/${test_name}_test/${test_name}_comparison.tsv
 
 test_name=gpas_illumina_short
@@ -51,20 +60,20 @@ echo Running ${test_name} test workflow
 mkdir -p /work/runs/${test_name}_test
 cd /work/runs/${test_name}_test
 
-nextflow run ${repo}/main.nf \
+nextflow kuberun oxfordmmm/${repo} \
         -with-trace -with-report -with-timeline -with-dag dag.png \
+        -r ${git_version} -latest \
         --seq_tech illumina \
-        -profile singularity \
-        -process.executor slurm \
+        -profile oke \
         --objstore /tmp/illumina_data_short.csv \
         --TESToutputMODE true \
         --outdir /work/output/${test_name}_test \
-        > nextflow.txt
+        > ${test_name}_nextflow.txt
 
-python3 ${repo}/tests/GPAS_tests_summary.py \
+python3 /data/pipelines/${repo}/tests/GPAS_tests_summary.py \
     -w /work/runs/${test_name}_test \
     -i /work/output/${test_name}_test/ \
     -t /work/output/${test_name}_test/${test_name}_summary.tsv  \
-    -e ${repo}/tests/${test_name}_expected.tsv \
+    -e /data/pipelines/${repo}/tests/${test_name}_expected.tsv \
     -c /work/output/${test_name}_test/${test_name}_comparison.tsv
 

--- a/workflows/illumina.nf
+++ b/workflows/illumina.nf
@@ -37,14 +37,14 @@ workflow sequenceAnalysisViridian {
 
         download_primers(params.primers)
 
-      	viridianPrimers(ch_filePairs.combine(download_primers.out).combine(getRefFiles.out.fasta))
+        viridianPrimers(ch_filePairs.combine(download_primers.out).combine(getRefFiles.out.fasta))
 
         viridian=viridianPrimers
 
       }
       else if (params.primers == 'auto') {
 
-      	viridianAuto(ch_filePairs.combine(getRefFiles.out.fasta))
+        viridianAuto(ch_filePairs.combine(getRefFiles.out.fasta))
 
         viridian=viridianAuto
 


### PR DESCRIPTION
These mainly mirror the changes from oxfordmmm/ncov2019-artic-nf#42 to oxfordmmm/ncov2019-artic-nf#58, but also adds:

- Changing manifestVersion type to work with APEX changes
- Using labels to group processes with the same container for readability
- Small type/ indentation corrections