### PR TITLE
Update `myMaxErrors` to avoid abandoning batches

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -22,7 +22,7 @@ params {
   myMaxRetries = 1
 
   // total number of error allowed per job 
-  myMaxErrors = 1000
+  myMaxErrors = 1000000
 
   // process fork limit
   myMaxForks = false


### PR DESCRIPTION
Due to recent changes pushed through to GPAS staging, the version of `nextflow` used now correctly gets the status of tasks run on pods. This means that the error strategy is actually being used now.

The current maximum errors in a batch is 1000 before abandoning. However, `nextflow` counts an error as a single task failing; so it is possible to reach this maximum errors with <1000 samples.

This simply increases the maximum errors to 1,000,000 with the aim of avoiding this behavior.