### PR TITLE
Ensure all processes have associated labels

### DIFF
--- a/modules/analysis.nf
+++ b/modules/analysis.nf
@@ -18,6 +18,7 @@ process pango {
 }
 
 process  download_primers {
+    label 'viridian'
     input:
         val(primers) 
 

--- a/modules/utils.nf
+++ b/modules/utils.nf
@@ -133,6 +133,8 @@ process getRefFiles {
     /**
     * fetches reference file from 
     */
+    tag {prefix}
+    label 'viridian'
 
     output:
     path("ref.fasta"), emit: fasta

--- a/nextflow.config
+++ b/nextflow.config
@@ -97,6 +97,8 @@ profiles {
 
     oke {
         k8s {
+	    httpReadTimeout = '120s'
+	    httpConnectTimeout = '120s'
             namespace = 'default'
             storageClaimName = 'default-nextflow-fss-storage-work-pvc'
             storageMountPath = '/work'

--- a/nextflow.config
+++ b/nextflow.config
@@ -97,8 +97,8 @@ profiles {
 
     oke {
         k8s {
-	    httpReadTimeout = '120s'
-	    httpConnectTimeout = '120s'
+	    httpReadTimeout = '240s'
+	    httpConnectTimeout = '240s'
             namespace = 'default'
             storageClaimName = 'default-nextflow-fss-storage-work-pvc'
             storageMountPath = '/work'

--- a/nextflow.config
+++ b/nextflow.config
@@ -97,8 +97,8 @@ profiles {
 
     oke {
         k8s {
-	    httpReadTimeout = '120s'
-	    httpConnectTimeout = '120s'
+	    httpReadTimeout = '60s'
+	    httpConnectTimeout = '60s'
             namespace = 'default'
             storageClaimName = 'default-nextflow-fss-storage-work-pvc'
             storageMountPath = '/work'

--- a/nextflow.config
+++ b/nextflow.config
@@ -97,8 +97,8 @@ profiles {
 
     oke {
         k8s {
-	    httpReadTimeout = '120s'
-	    httpConnectTimeout = '120s'
+	    httpReadTimeout = '600s'
+	    httpConnectTimeout = '600s'
             namespace = 'default'
             storageClaimName = 'default-nextflow-fss-storage-work-pvc'
             storageMountPath = '/work'

--- a/nextflow.config
+++ b/nextflow.config
@@ -97,8 +97,8 @@ profiles {
 
     oke {
         k8s {
-	    httpReadTimeout = '1800s'
-	    httpConnectTimeout = '1800s'
+	    httpReadTimeout = '60s'
+	    httpConnectTimeout = '60s'
             namespace = 'default'
             storageClaimName = 'default-nextflow-fss-storage-work-pvc'
             storageMountPath = '/work'

--- a/nextflow.config
+++ b/nextflow.config
@@ -97,8 +97,8 @@ profiles {
 
     oke {
         k8s {
-	    httpReadTimeout = '60s'
-	    httpConnectTimeout = '60s'
+	    httpReadTimeout = '120s'
+	    httpConnectTimeout = '120s'
             namespace = 'default'
             storageClaimName = 'default-nextflow-fss-storage-work-pvc'
             storageMountPath = '/work'

--- a/nextflow.config
+++ b/nextflow.config
@@ -97,8 +97,8 @@ profiles {
 
     oke {
         k8s {
-	    httpReadTimeout = '600s'
-	    httpConnectTimeout = '600s'
+	    httpReadTimeout = '1800s'
+	    httpConnectTimeout = '1800s'
             namespace = 'default'
             storageClaimName = 'default-nextflow-fss-storage-work-pvc'
             storageMountPath = '/work'

--- a/nextflow.config
+++ b/nextflow.config
@@ -97,8 +97,6 @@ profiles {
 
     oke {
         k8s {
-	    httpReadTimeout = '240s'
-	    httpConnectTimeout = '240s'
             namespace = 'default'
             storageClaimName = 'default-nextflow-fss-storage-work-pvc'
             storageMountPath = '/work'


### PR DESCRIPTION
As the Nextflow version issue was caused by the default container not having an appropriate entry point, adding labels to all processes avoids using the default container.

This adds labels for two processes. This ensures that these steps are run using the viridian container (they are viridian-related processed) - ensuring that the default container is not used.